### PR TITLE
test: add test for env var names

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Alchemy API key
 
 If given, the action substitute missing RPC_URLs with one constructed from the given key.
 
+### Supported Environment Variables
+
+The supported environment variables are documented in [this](src/lib.test.ts) test.
+
 #### Usage
 
 ```yaml

--- a/src/lib.test.ts
+++ b/src/lib.test.ts
@@ -1,7 +1,7 @@
 import { describe } from "node:test";
 import { expect, it } from "vitest";
 import { networkMap } from "./alchemyIds";
-import { ChainId, getRPCUrl, supportedChainIds } from "./lib";
+import { ChainId, getNetworkEnv, getRPCUrl, supportedChainIds } from "./lib";
 
 describe("lib", () => {
   it("should use env var if given", () => {
@@ -27,5 +27,40 @@ describe("lib", () => {
 
   it.each(supportedChainIds)("should return supported chain %s", (chainId) => {
     expect(getRPCUrl(chainId, "abc")).toMatchSnapshot(networkMap[chainId]);
+  });
+
+  it("has sensible env names for RPC_", () => {
+    const envs = Object.fromEntries(
+      supportedChainIds.map((chainId) => [getNetworkEnv(chainId), chainId]),
+    );
+
+    expect(envs).toMatchInlineSnapshot(`
+      {
+        "RPC_ARBITRUM_GOERLI": 421613,
+        "RPC_ARBITRUM_ONE": 42161,
+        "RPC_ARBITRUM_SEPOLIA": 421614,
+        "RPC_AVALANCHE": 43114,
+        "RPC_BASE": 8453,
+        "RPC_BASE_SEPOLIA": 84532,
+        "RPC_BNB": 56,
+        "RPC_FANTOM": 250,
+        "RPC_FANTOM_TESTNET": 4002,
+        "RPC_FUJI": 43113,
+        "RPC_GNOSIS": 100,
+        "RPC_GOERLI": 5,
+        "RPC_MAINNET": 1,
+        "RPC_METIS": 1088,
+        "RPC_MUMBAI": 80001,
+        "RPC_OPTIMISM": 10,
+        "RPC_OPTIMISM_GOERLI": 420,
+        "RPC_OPTIMISM_SEPOLIA": 11155420,
+        "RPC_POLYGON": 137,
+        "RPC_SCROLL": 534352,
+        "RPC_SCROLL_SEPOLIA": 534351,
+        "RPC_SEPOLIA": 11155111,
+        "RPC_ZKEVM": 1101,
+        "RPC_ZKSYNC": 324,
+      }
+    `);
   });
 });


### PR DESCRIPTION
in regards to [this](https://github.com/bgd-labs/action-rpc-env/pull/16#discussion_r1828924769) comment by @sakulstra, I figured it makes sense to have the available `RPC_` envs in a readable format in case of a need to debug.

just a snapshot so we can use this as a reference when passing env vars.