### PR TITLE
🐛 Change gnosis public RPC

### DIFF
--- a/src/publicRPCs.ts
+++ b/src/publicRPCs.ts
@@ -11,7 +11,7 @@ export const publicRPCs = {
   [ChainId.base]: "https://base.llamarpc.com",
   [ChainId.bnb]: "https://binance.llamarpc.com",
   [ChainId.metis]: "https://andromeda.metis.io/?owner=1088",
-  [ChainId.gnosis]: "https://rpc.gnosis.gateway.fm",
+  [ChainId.gnosis]: "https://gnosis.drpc.org",
   [ChainId.scroll]: "https://rpc.scroll.io",
   [ChainId.zksync]: "https://mainnet.era.zksync.io",
   [ChainId.fantom]: "https://rpc.ftm.tools",

--- a/src/publicRPCs.ts
+++ b/src/publicRPCs.ts
@@ -11,7 +11,7 @@ export const publicRPCs = {
   [ChainId.base]: "https://base.llamarpc.com",
   [ChainId.bnb]: "https://binance.llamarpc.com",
   [ChainId.metis]: "https://andromeda.metis.io/?owner=1088",
-  [ChainId.gnosis]: "https://rpc.ankr.com/gnosis",
+  [ChainId.gnosis]: "https://rpc.gnosis.gateway.fm",
   [ChainId.scroll]: "https://rpc.scroll.io",
   [ChainId.zksync]: "https://mainnet.era.zksync.io",
   [ChainId.fantom]: "https://rpc.ftm.tools",


### PR DESCRIPTION
Changed the current Gnosis public RPC (https://rpc.ankr.com/gnosis) for a new one https://rpc.gnosis.gateway.fm (specified here: https://docs.gnosischain.com/tools/RPC%20Providers/).

I can also choose another one more privacy friendly as you want.

The changed is needed because Ankr public RPC can't be used anymore without an API key:
`Error: -32000, "Unauthorized: You must authenticate your request with an API key. Create an account on https://www.ankr.com/rpc/ [...]"`

And so this is a blocker in apps that use this repo (especially risk stewards, when trying to generate calldatas for the gnosis chain)